### PR TITLE
improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Persistent BinderHub
 
 This is a Helm chart to install a persistent BinderHub. 
-It simply configures and extends [BinderHub chart](https://github.com/jupyterhub/binderhub) to bring persistent storage feature, 
+It simply configures and extends [BinderHub chart](https://github.com/jupyterhub/binderhub) to add persistent storage, 
 it doesn't define any new component. 
 Therefore before using this chart it is required that you read through [BinderHub documentation](https://binderhub.readthedocs.io/en/latest/), 
 you know how to deploy a [standard BinderHub](http://mybinder.org/) 
@@ -88,7 +88,7 @@ https://gesiscss.github.io/persistent_binderhub/
 
 The installation consists of 2 steps. As a first step we install the chart, 
 then we will finalize the configuration of the Binder service 
-and upgrade the chart to apply last changes in the config.
+and upgrade the chart to apply final changes in the config.
 
 To install the chart with the release name `pbhub` into namespace `pbhub-ns`:
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ and it is recommended to use it only for testing purposes.
 
 ## Installing the chart
 
+First of all you can find the list of charts here: 
+https://gesiscss.github.io/persistent_binderhub/
+
 The installation consists of 2 steps. As a first step we install the chart, 
 then we will finalize the configuration of the Binder service 
 and upgrade the chart to apply last changes in the config.
@@ -109,9 +112,9 @@ helm search persistent_binderhub
 ```
 
 After the first step, run `kubectl get service proxy-public --namespace=$NAMESPACE` 
-and copy the IP address under `EXTERNAL-IP`, which is the IP address of JupyterHub. 
+and copy the IP address under `EXTERNAL-IP`, which is the IP of the JupyterHub. 
 Then run `kubectl get service binder --namespace=$NAMESPACE` 
-and again copy the IP address under `EXTERNAL-IP`, which is the IP address of Binder service. 
+and again copy the IP address under `EXTERNAL-IP`, which is the IP of the Binder service. 
 
 With the IP addresses you just acquired update your `config.yaml`:
 
@@ -135,7 +138,11 @@ helm upgrade $RELEASENAME persistent_binderhub/persistent_binderhub --version=0.
              --debug
 ```
 
-Here you can find the list of charts: https://gesiscss.github.io/persistent_binderhub/
+When the installation is done, 
+the persistent BinderHub will be available at "http://<JupyterHub_IP>", 
+and there (at JupyterHub home page) you will see a customized BinderHub UI for persistence, 
+which is the place that users will interact with the system mostly.  
+The standard BinderHub will be available at "http://<JupyterHub_IP>/services/binder" as a service of JupyterHub. 
 
 ## Uninstalling the chart
 


### PR DESCRIPTION
this PR improves docs based on https://github.com/gesiscss/persistent_binderhub/issues/5#issuecomment-670393399

@sgibson91 I would be happy if you could review :)

> Document the gotcha about dummy IPs. Folks like me coming from cloud-based BHub deployments would probably expect the chart to "just work" and we update it with the IP addresses when they're created. Explicitly saying that this chart won't work that way will save some confusion.

For this I made a PR in binderhub repo: https://github.com/jupyterhub/binderhub/pull/1139

> Document how and why the hub/binder URLs are different from the standard BHub. Again coming from the standard chart, I would never have assumed that these values needed to be different. Also a little bit of explanation as to why it's set up that way might be nice for the curious, and also admins who may need to debug at some point.

Hopefully this is better documented now.

> The URLs provided to the OAuth Provider are different than those described in the z2jh auth docs. With the explanation about the URLs from the previous point, this need be nothing more than "Here's the z2jh auth guide. Remember, the URLs you will be providing are the following..."

I guess here you confused the config for `jupyterhub.hub.services.binderhub` with `jupyterhub.auth`?