### PR TITLE
Suport for custom repo providers

### DIFF
--- a/persistent_binderhub/files/jupyterhub/statics/persistent_bhub.js
+++ b/persistent_binderhub/files/jupyterhub/statics/persistent_bhub.js
@@ -53,24 +53,8 @@ $(document).ready(function() {
             var ref = $(this).prop('id').replace("launch-","");
             var repo_url = $(this).data('url');
             var repo_url_lower = repo_url.toLowerCase();
-            var provider_prefix;
-            var provider_prefix_selected;
-            // TODO handle provider prefix for other providers
-            if (repo_url_lower.indexOf('github.com') !== -1 && repo_url_lower.indexOf('gist.github.com') === -1) {
-               provider_prefix = 'gh';
-               provider_prefix_selected = 'GitHub';
-            } else if (repo_url_lower.indexOf('gitlab.com') !== -1) {
-               // gitlab.com
-               provider_prefix = 'gl';
-               provider_prefix_selected = 'GitLab.com';
-            } else if (repo_url_lower.indexOf('gist.github.com') !== -1) {
-               // gist.github.com
-               provider_prefix = 'gist';
-               provider_prefix_selected = 'Gist';
-            } else {
-               provider_prefix = 'git';
-               provider_prefix_selected = 'Git repository';
-            }
+            var provider_prefix = $(this).data('provider_prefix');
+            var provider_prefix_selected = $(this).data('provider_name');
             $('#provider_prefix').val(provider_prefix);
             $('#provider_prefix-selected').text(provider_prefix_selected);
             $('#ref').val(ref);

--- a/persistent_binderhub/files/jupyterhub/templates/projects_form.html
+++ b/persistent_binderhub/files/jupyterhub/templates/projects_form.html
@@ -1,3 +1,4 @@
+  {% set repo_providers = user.spawner.repo_providers %}
   <div class="row form-group"></div>
   <div class="row build-project-container">
     <div class="col-lg-12 build-form-container">
@@ -20,15 +21,9 @@
               <span class="caret"></span>
               </button>
               <ul class="dropdown-menu" id="provider_prefix_sel">
-                <li class="dropdown-item" value="gh"><a href="#">GitHub</a></li>
-                <li class="dropdown-item" value="gist"><a href="#">Gist</a></li>
-                <li class="dropdown-item" value="gl"><a href="#">GitLab.com</a></li>
-                <li class="dropdown-item" value="git"><a href="#">Git repository</a></li>
-                {# TODO enable zenodo, figshare and others #}
-{#                <li class="dropdown-item" value="zenodo"><a href="#">Zenodo DOI</a></li>#}
-{#                <li class="dropdown-item" value="figshare"><a href="#">Figshare DOI</a></li>#}
-{#                <li class="dropdown-item" value="hydroshare"><a href="#">Hydroshare resource</a></li>#}
-{#                <li class="dropdown-item" value="dataverse"><a href="#">Dataverse DOI</a></li>#}
+                {% for repo_provider in repo_providers %}
+                <li class="dropdown-item" value="{{ repo_provider['prefix'] }}"><a href="#">{{ repo_provider['name'] }}</a></li>
+                {% endfor %}
               </ul>
             </div>
             <input class="form-control" type="text" id="repository" data-lpignore="true" placeholder="GitHub repository name or URL"/>

--- a/persistent_binderhub/files/jupyterhub/templates/projects_table.html
+++ b/persistent_binderhub/files/jupyterhub/templates/projects_table.html
@@ -30,7 +30,9 @@
                           <a role="button" id="launch-{{ project['ref'] }}"
                              class="project-launch btn btn-sm {% if project_active %}btn-primary{% else %}btn-warning{% endif %}{% if project_not_active %} hidden{% endif %}"
                              href="{% if project_active %}{{ url }}{% else %}#{% endif %}"
-                             data-url="{{ project['repo_url'] }}">
+                             data-url="{{ project['repo_url'] }}"
+                             data-provider_prefix="{{ project['provider_prefix'] }}"
+                             data-provider_name="{{ project['provider_name'] }}">
                              {% if project_active %}My Server{% else %}Launch{% endif %}
                           </a>
                           <a role="button" id="delete-{{ project['ref'] }}"


### PR DESCRIPTION
This MR adds support for custom repo providers via the configurable `repo_provider` field in `PersistentBinderSpawner`.
At the same time it also deduplicates logic which was present in both UI and the spawner.