### PR TITLE
add option to disable mounting /projects

### DIFF
--- a/persistent_binderhub/files/jupyterhub/persistent_bhub_config.py
+++ b/persistent_binderhub/files/jupyterhub/persistent_bhub_config.py
@@ -211,7 +211,11 @@ class PersistentBinderSpawner(KubeSpawner):
         for i, v_m in enumerate(self.volume_mounts):
             if v_m['mountPath'] == projects_volume_mount['mountPath']:
                 del self.volume_mounts[i]
-        self.volume_mounts.append(projects_volume_mount)
+
+        # only mount /projects in the user server if mounting all projects is enabled
+        if z2jh.get_config('custom.mount_all_projects'):
+            self.volume_mounts.append(projects_volume_mount)
+
         # mountPath is /home/jovyan, this is set in z2jh helm chart values.yaml
         # mount_path = "~/"
         # mount_path = "$(HOME)"

--- a/persistent_binderhub/values.yaml
+++ b/persistent_binderhub/values.yaml
@@ -67,6 +67,7 @@ binderhub:
     custom:
       cors: *cors
       binderauth_enabled: true
+      mount_all_projects: true
       default_project:
         repo_url: "https://github.com/gesiscss/persistent_binderhub"
         ref: "0.2.0-n528.1"


### PR DESCRIPTION
We do not want the /projects dir to be mounted in the user server because we consider that feature a security risk. I have added a config option to disable it. We would be glad if you could merge this, so others can use that option if they want to, and we don't need to maintain a custom build of persistent_binderhub.