### PR TITLE
Add a single init_container instead of overwriting init_containers

### DIFF
--- a/persistent_binderhub/files/jupyterhub/persistent_bhub_config.py
+++ b/persistent_binderhub/files/jupyterhub/persistent_bhub_config.py
@@ -195,13 +195,13 @@ class PersistentBinderSpawner(KubeSpawner):
         #  because start command is run as an ENTRYPOINT and initcontainer's command overwrites it
         #  But start command will be executed in notebook container (because we dont define a custom command for it),
         #  so change will take place there, and on user's side, there is no problem
-        self.init_containers = [{
+        self.init_containers.append({
             "name": "project-manager",
             "image": self.image,
             "command": command,
             # volumes is already defined for notebook container (self.volumes)
             "volume_mounts": [projects_volume_mount],
-        }]
+        })
 
         # notebook container (user server)
         # mount all projects (complete user disk) to /projects


### PR DESCRIPTION
Downstream users can add more initContainers

fixes https://github.com/gesiscss/persistent_binderhub/issues/17

@g-braeunlich can you have a look?
Instead of the check for "project-manager" I am just appending it to the list of init_containers,
does this work for you? You can append another init_container in the subclassed spawner.

