### PR TITLE
Fix path to introduction notebook

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/jupyter/docker-stacks/tree/master/base-notebook
 FROM jupyter/base-notebook:hub-1.4.2
 
-COPY intro_to_persistent_binderhub.ipynb ${HOME}/intro_to_persistent_binderhub.ipynb
+COPY .binder/intro_to_persistent_binderhub.ipynb ${HOME}/intro_to_persistent_binderhub.ipynb
 RUN rm -rf ${HOME}/work
 USER root
 RUN chown -R ${NB_UID} ${HOME}


### PR DESCRIPTION
Binder build of this repository fails with the following output:
```
Waiting for build to start...
Picked Git content provider.
Cloning into '/tmp/repo2dockerjuuhwwu_'...
HEAD is now at 9936fc2 Merge pull request #26 from gesiscss/ctr26
Using DockerBuildPack builder
Step 1/9 : FROM jupyter/base-notebook:hub-1.4.2
 ---> 3059097d7b03
Step 2/9 : COPY intro_to_persistent_binderhub.ipynb ${HOME}/intro_to_persistent_binderhub.ipynb
COPY failed: file not found in build context or excluded by .dockerignore: stat intro_to_persistent_binderhub.ipynb: file does not exist
```
I fixed the error by changing
```
COPY intro_to_persistent_binderhub.ipynb ${HOME}/intro_to_persistent_binderhub.ipynb
```
to
```
COPY .binder/intro_to_persistent_binderhub.ipynb ${HOME}/intro_to_persistent_binderhub.ipynb
```
Fixes #29