### PR TITLE
Require bootstrap to fix delete modal

### DIFF
--- a/persistent_binderhub/files/jupyterhub/statics/persistent_bhub.js
+++ b/persistent_binderhub/files/jupyterhub/statics/persistent_bhub.js
@@ -1,4 +1,4 @@
-require(["jquery", "jhapi", "moment"], function($, JHAPI, moment) {
+require(["jquery", "jhapi", "moment", "bootstrap"], function($, JHAPI, moment) {
   "use strict";
 
   var base_url = window.jhdata.base_url;


### PR DESCRIPTION
The delete button didn't work because bootstrap was never imported. Not sure if this is the correct place to import bootstrap, but it works for me.

Fixes #30